### PR TITLE
🍒 Board, Reply 도메인 기반 DB 테이블 생성 및 INSERT 테스트

### DIFF
--- a/ziczone/src/main/java/org/zerock/ziczone/domain/Board.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/domain/Board.java
@@ -1,0 +1,47 @@
+package org.zerock.ziczone.domain;
+
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long corrId;
+
+    @Column(length = 100, nullable = false)
+    private String corrTitle;
+
+    @Column(length = 255, nullable = false)
+    private String corrContent;
+
+    @Column(length = 100, nullable = false)
+    private String corrPdf;
+
+    @Column(nullable = false)
+    private Integer corrPoint;
+
+    private Integer corrView;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime corrCreate;
+
+    @UpdateTimestamp
+    @Column(nullable = false, updatable = true)
+    private LocalDateTime corrModify;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/domain/Reply.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/domain/Reply.java
@@ -1,0 +1,41 @@
+package org.zerock.ziczone.domain;
+
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class Reply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commId;
+
+    private String commContent;
+
+    private boolean commSelection;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime commCreate;
+
+    @UpdateTimestamp
+    @Column(nullable = false, updatable = true)
+    private LocalDateTime commModify;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "corr_id")
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/BoardRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package org.zerock.ziczone.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.ziczone.domain.Board;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/ReplyRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/ReplyRepository.java
@@ -1,0 +1,7 @@
+package org.zerock.ziczone.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zerock.ziczone.domain.Reply;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+}

--- a/ziczone/src/test/java/org/zerock/ziczone/repository/UserRepositoryTests.java
+++ b/ziczone/src/test/java/org/zerock/ziczone/repository/UserRepositoryTests.java
@@ -1,12 +1,16 @@
 package org.zerock.ziczone.repository;
 
 import lombok.extern.log4j.Log4j2;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.zerock.ziczone.domain.*;
 
+import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @SpringBootTest
 @Log4j2
@@ -36,6 +40,10 @@ public class UserRepositoryTests {
     private CurriculumRepository curriculumRepository;
     @Autowired
     private EtcRepository etcRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private ReplyRepository replyRepository;
 
     @Test
     public void testPersonalInsert(){
@@ -212,5 +220,52 @@ public class UserRepositoryTests {
         etcRepository.save(etc);
         log.info("Etc saved: " + etc);
 
+    }
+
+    @Test
+    public void testBoardInsert(){
+        // DB에 있는 user_id
+        Long userId = 1L;
+        User user = User.builder()
+                .userId(userId)
+                .build();
+
+        Board board = Board.builder()
+                .corrTitle("테스트 제목")
+                .corrContent("테스트 내용")
+                .corrPdf("테스트 pdf")
+                .corrPoint(100)
+                .corrCreate(LocalDateTime.now())
+                .corrModify(LocalDateTime.now())
+                .user(user)
+                .build();
+
+        boardRepository.save(board);
+        log.info("Board saved: " + board);
+    }
+
+    @Test
+    public void testReplyInsert(){
+        Long userId = 1L;
+        User user = User.builder()
+                .userId(userId)
+                .build();
+
+        Long corrId = 2L;
+        Board board = Board.builder()
+                .corrId(corrId)
+                .build();
+
+        Reply reply = Reply.builder()
+                .commContent("테스트 내용")
+                .commSelection(false)
+                .commCreate(LocalDateTime.now())
+                .commModify(LocalDateTime.now())
+                .user(user)
+                .board(board)
+                .build();
+
+        replyRepository.save(reply);
+        log.info("Reply saved: " + reply);
     }
 }


### PR DESCRIPTION
**도메인 엔티티 추가 및 DB 테이블 생성**
- Board와 Reply 엔티티를 정의하고 이를 통해 데이터베이스 테이블 생성

**레포지토리 구현**
- BoardRepository : Board 엔티티에 대한 CRUD 작업을 처리하기 위한 JPA 레포지토리
- ReplyRepository :  Reply 엔티티에 대한 CRUD 작업을 처리하기 위한 JPA 레포지토리

**테스트 코드 추가**
- testBoardInsert(), testReplyInsert()
