### PR TITLE
지원서 조회, 수정,생성, 삭제

### DIFF
--- a/ziczone/src/main/java/org/zerock/ziczone/controller/MyPageResumeConroller.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/controller/MyPageResumeConroller.java
@@ -1,0 +1,70 @@
+package org.zerock.ziczone.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.zerock.ziczone.dto.mypage.ResumeDTO;
+import org.zerock.ziczone.service.myPage.ResumeService;
+
+@RestController
+@RequestMapping("/api/resumes")
+@RequiredArgsConstructor
+public class MyPageResumeConroller {
+
+    private final ResumeService resumeService;
+
+
+//    /**
+//     * 지원서 생성
+//     * 지원서 조회시 생성하고 있어서 사용 X
+//     * @param userId
+//     * @param resumeDTO
+//     * @return
+//     */
+//    @PostMapping("/{userId}")
+//    public ResponseEntity<String> createResume(@PathVariable Long userId, @RequestBody ResumeDTO resumeDTO) {
+//        resumeService.createResume(resumeDTO, userId);
+//        return ResponseEntity.ok("Resume created successfully");
+//    }
+
+
+    /**
+     * 지원서 조회 & 생성
+     * 지원서 작성 버튼을 클릭 했을 때 Resume 테이블에 userId가 저장되어 있다면 저장된 내용을 가져오고,
+     * 조회된 내용이 없을 시 튜플을 생성해서 리턴해준다.(String형식은 빈 문자열으로, 날짜형식은 현재시간으로 값을 넣어준다.)
+     * @param userId
+     * @return
+     */
+    @GetMapping("/{userId}")
+    public ResponseEntity<ResumeDTO> getResume(@PathVariable Long userId) {
+        ResumeDTO resumeDTO = resumeService.getResume(userId);
+        return ResponseEntity.ok(resumeDTO);
+    }
+
+    /** 지원서 수정
+     * 수정을 원할 시 작성하고 싶은 부분만 작성하여 요청을 작성해주면 된다.
+     * @param userId
+     * @param resumeDTO
+     * @return ResponseEntity.ok || status
+     */
+    @PutMapping("/{userId}")
+    public ResponseEntity<String> updateResume(@PathVariable Long userId, @RequestBody ResumeDTO resumeDTO) {
+        try {
+            resumeService.updateResume(userId, resumeDTO);
+            return ResponseEntity.ok("Resume updated successfully");
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("Failed to update resume");
+        }
+    }
+
+    /**
+     * 지원서 삭제
+     * @param userId
+     * @return ResponseEntity.ok
+     */
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> deleteResume(@PathVariable Long userId) {
+        resumeService.deleteResume(userId);
+        return ResponseEntity.ok("Resume deleted successfully");
+    }
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/domain/application/Archive.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/domain/application/Archive.java
@@ -6,7 +6,7 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString

--- a/ziczone/src/main/java/org/zerock/ziczone/domain/application/Resume.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/domain/application/Resume.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/ArchiveDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/ArchiveDTO.java
@@ -1,0 +1,38 @@
+package org.zerock.ziczone.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.zerock.ziczone.domain.application.Archive;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArchiveDTO {
+    private Long arch_id;
+    private String arch_git;
+    private String arch_notion;
+    private String arch_blog;
+
+    // DTO to Entity
+    public Archive toEntity() {
+        return Archive.builder()
+                .archId(this.arch_id)
+                .archGit(this.arch_git)
+                .archNotion(this.arch_notion)
+                .archBlog(this.arch_blog)
+                .build();
+    }
+
+    // Entity to DTO
+    public static ArchiveDTO fromEntity(Archive entity) {
+        return ArchiveDTO.builder()
+                .arch_id(entity.getArchId())
+                .arch_git(entity.getArchGit())
+                .arch_notion(entity.getArchNotion())
+                .arch_blog(entity.getArchBlog())
+                .build();
+    }
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CareerDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CareerDTO.java
@@ -1,0 +1,41 @@
+package org.zerock.ziczone.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.zerock.ziczone.domain.application.Career;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class CareerDTO {
+    private Long career_id;
+    private String career_name;
+    private String career_job;
+    private String career_position;
+    private String career_date;
+
+    // DTO to Entity
+    public Career toEntity() {
+        return Career.builder()
+                .careerId(this.career_id)
+                .careerName(this.career_name)
+                .careerJob(this.career_job)
+                .careerPosition(this.career_position)
+                .careerDate(this.career_date)
+                .build();
+    }
+
+    // Entity to DTO
+    public static CareerDTO fromEntity(Career entity) {
+        return CareerDTO.builder()
+                .career_id(entity.getCareerId())
+                .career_name(entity.getCareerName())
+                .career_job(entity.getCareerJob())
+                .career_position(entity.getCareerPosition())
+                .career_date(entity.getCareerDate())
+                .build();
+    }
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CertificateDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CertificateDTO.java
@@ -1,0 +1,36 @@
+package org.zerock.ziczone.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.zerock.ziczone.domain.application.Certificate;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class CertificateDTO {
+    private Long cert_id;
+    private String cert;
+    private String cert_date;
+
+    // DTO to Entity
+    public Certificate toEntity() {
+        return Certificate.builder()
+                .certId(this.cert_id)
+                .cert(this.cert)
+                .certDate(this.cert_date)
+                .build();
+    }
+
+    // Entity to DTO
+    public static CertificateDTO fromEntity(Certificate entity) {
+        return CertificateDTO.builder()
+                .cert_id(entity.getCertId())
+                .cert(entity.getCert())
+                .cert_date(entity.getCertDate())
+                .build();
+    }
+
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CompanyUserUpdateDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CompanyUserUpdateDTO.java
@@ -24,7 +24,9 @@ public class CompanyUserUpdateDTO {
 
     private String companyLogo;
 
-    private String companyUserPassword;
+    private String changePassword;
+
+    private String currentPassword;
 
 //    private String companyCeo; // 추후 변경할 수 있어 주석 처리
 

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CurriculumDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/CurriculumDTO.java
@@ -1,0 +1,38 @@
+package org.zerock.ziczone.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.zerock.ziczone.domain.application.Curriculum;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class CurriculumDTO {
+    private Long curri_id;
+    private String curri_content;
+    private String curri_company;
+    private String curri_date;
+
+    // DTO to Entity
+    public Curriculum toEntity() {
+        return Curriculum.builder()
+                .curriId(this.curri_id)
+                .curriContent(this.curri_content)
+                .curriCompany(this.curri_company)
+                .curriDate(this.curri_date)
+                .build();
+    }
+
+    // Entity to DTO
+    public static CurriculumDTO fromEntity(Curriculum entity) {
+        return CurriculumDTO.builder()
+                .curri_id(entity.getCurriId())
+                .curri_content(entity.getCurriContent())
+                .curri_company(entity.getCurriCompany())
+                .curri_date(entity.getCurriDate())
+                .build();
+    }
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/EducationDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/EducationDTO.java
@@ -1,0 +1,38 @@
+package org.zerock.ziczone.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.zerock.ziczone.domain.application.Education;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class EducationDTO {
+    private Long edu_id;
+    private String edu;
+    private String credit;
+    private String edu_date;
+
+    // DTO to Entity
+    public Education toEntity() {
+        return Education.builder()
+                .eduId(this.edu_id)
+                .edu(this.edu)
+                .credit(this.credit)
+                .eduDate(this.edu_date)
+                .build();
+    }
+
+    // Entity to DTO
+    public static EducationDTO fromEntity(Education entity) {
+        return EducationDTO.builder()
+                .edu_id(entity.getEduId())
+                .edu(entity.getEdu())
+                .credit(entity.getCredit())
+                .edu_date(entity.getEduDate())
+                .build();
+    }
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/EtcDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/EtcDTO.java
@@ -1,0 +1,35 @@
+package org.zerock.ziczone.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.zerock.ziczone.domain.application.Etc;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class EtcDTO {
+    private Long etc_id;
+    private String etc_content;
+    private String etc_date;
+
+    // DTO to Entity
+    public Etc toEntity() {
+        return Etc.builder()
+                .etcId(this.etc_id)
+                .etcContent(this.etc_content)
+                .etcDate(this.etc_date)
+                .build();
+    }
+
+    // Entity to DTO
+    public static EtcDTO fromEntity(Etc entity) {
+        return EtcDTO.builder()
+                .etc_id(entity.getEtcId())
+                .etc_content(entity.getEtcContent())
+                .etc_date(entity.getEtcDate())
+                .build();
+    }
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/ResumeDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/mypage/ResumeDTO.java
@@ -1,14 +1,18 @@
 package org.zerock.ziczone.dto.mypage;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.zerock.ziczone.domain.application.Resume;
+import org.zerock.ziczone.domain.member.PersonalUser;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 public class ResumeDTO {
@@ -17,8 +21,51 @@ public class ResumeDTO {
     private String resumeDate;
     private String phoneNum;
     private String resumePhoto;
+    private String resumeEmail;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime resumeCreate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime resumeUpdate;
     private String personalState;
     private Long personalId;
+    private ArchiveDTO archive; // One-to-One relationship
+    private List<EtcDTO> etcs; // One-to-Many relationship
+    private List<CurriculumDTO> curriculums; // One-to-Many relationship
+    private List<CareerDTO> careers; // One-to-Many relationship
+    private List<EducationDTO> educations; // One-to-Many relationship
+    private List<CertificateDTO> certificates; // One-to-Many relationship
+
+    // DTO to Entity
+    public Resume toEntity() {
+        return Resume.builder()
+                .resumeId(this.resumeId)
+                .resumeName(this.resumeName)
+                .resumeDate(this.resumeDate)
+                .phoneNum(this.phoneNum)
+                .resumeEmail(this.resumeEmail)
+                .resumePhoto(this.resumePhoto)
+                .resumeCreate(this.resumeCreate)
+                .resumeUpdate(this.resumeUpdate)
+                .personalState(this.personalState)
+                .personalUser(PersonalUser.builder().personalId(this.personalId).build()) // Assumed constructor
+                .build();
+    }
+
+    // Entity to DTO
+    public static ResumeDTO fromEntity(Resume entity) {
+        return ResumeDTO.builder()
+                .resumeId(entity.getResumeId())
+                .resumeName(entity.getResumeName())
+                .resumeDate(entity.getResumeDate())
+                .phoneNum(entity.getPhoneNum())
+                .resumeEmail(entity.getResumeEmail())
+                .resumePhoto(entity.getResumePhoto())
+                .resumeCreate(entity.getResumeCreate())
+                .resumeUpdate(entity.getResumeUpdate())
+                .personalState(entity.getPersonalState())
+                .personalId(entity.getPersonalUser().getPersonalId()) // Assumed getter
+                .build();
+    }
+
+
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/payment/PaymentDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/payment/PaymentDTO.java
@@ -1,0 +1,21 @@
+package org.zerock.ziczone.dto.payment;
+
+import lombok.NonNull;
+
+public class PaymentDTO {
+
+
+//    @NonNull
+//    private PayType payType;
+
+    @NonNull
+    private Long amount;
+
+    @NonNull
+    private String orderName;
+
+    private String yourSucceesUrl;
+
+    private String yourFaulUrl;
+
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/application/ArchiveRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/application/ArchiveRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface ArchiveRepository extends JpaRepository<Archive, Long> {
     List<Archive> findByResume_ResumeId(Long resumeId);
+
+    void deleteByResume_ResumeId(Long resumeId);
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/application/CareerRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/application/CareerRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface CareerRepository extends JpaRepository<Career, Long> {
     List<Career> findByResume_ResumeId(Long resumeId);
+
+    void deleteByResume_ResumeId(Long resumeId);
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/application/CertificateRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/application/CertificateRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface CertificateRepository extends JpaRepository<Certificate, Long> {
     List<Certificate> findByResume_ResumeId(Long ResumeId);
+
+    void deleteByResume_ResumeId(Long resumeId);
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/application/CurriculumRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/application/CurriculumRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface CurriculumRepository extends JpaRepository<Curriculum, Long> {
     List<Curriculum> findByResume_ResumeId(Long resumeId);
+
+    void deleteByResume_ResumeId(Long resumeId);
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/application/EducationRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/application/EducationRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface EducationRepository extends JpaRepository<Education, Long> {
     List<Education> findByResume_ResumeId(Long resumeId);
+
+    void deleteByResume_ResumeId(Long resumeId);
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/application/EtcRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/application/EtcRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface EtcRepository extends JpaRepository<Etc, Long> {
     List<Etc> findByResume_ResumeId(Long resumeId);
+
+    void deleteByResume_ResumeId(Long resumeId);
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/repository/member/PersonalUserRepository.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/repository/member/PersonalUserRepository.java
@@ -4,12 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.zerock.ziczone.domain.member.PersonalUser;
+import org.zerock.ziczone.domain.member.User;
 
 import java.util.List;
 
 public interface PersonalUserRepository extends JpaRepository<PersonalUser, Long> {
     PersonalUser findByPersonalId(Long personalId);
-
     PersonalUser findByUser_UserId(Long personalId);
 
     // JPQL 쿼리를 사용하여 isPersonalVisible 속성이 true인 PersonalUser의 personalId 목록을 반환

--- a/ziczone/src/main/java/org/zerock/ziczone/service/myPage/MyPageService.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/service/myPage/MyPageService.java
@@ -26,8 +26,14 @@ public interface MyPageService {
     AggregatedDataDTO getAggregatedData(Long userId);
     // Pick 탭 리스트 조회 (개인 회원)
     List<CompanyUserDTO> getPicksByPersonalUsers(Long userId);
-    //(커스텀 DTO) 내가 쓴 댓글 조회
+    // (커스텀 DTO) 내가 쓴 댓글 조회
     List<MyCommentListDTO> MyCommList(Long userId);
+    // 지원서 조회
+    ResumeDTO getResume(Long userId);
+    // 지원서 수정
+    ResumeDTO setResume(Long userId, ResumeDTO resumeDTO);
+    // 지원서 삭제[부기능]
+//    ResumeDTO deleteResume(Long userId, ResumeDTO resumeDTO);
     // 토스 결제
 
 

--- a/ziczone/src/main/java/org/zerock/ziczone/service/myPage/ResumeService.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/service/myPage/ResumeService.java
@@ -1,0 +1,17 @@
+package org.zerock.ziczone.service.myPage;
+
+import org.zerock.ziczone.dto.mypage.ResumeDTO;
+
+import java.util.Optional;
+
+public interface ResumeService {
+    // 지원서 생성
+    public ResumeDTO createResume(ResumeDTO resumeDTO, Long userId);
+    // 지원서 조회
+    public ResumeDTO getResume(Long userId);
+    // 지원서 수정
+    public ResumeDTO updateResume(Long userId, ResumeDTO resumeDTO);
+    // 지원서 삭제
+    public void deleteResume(Long userId);
+
+}

--- a/ziczone/src/main/java/org/zerock/ziczone/service/myPage/ResumeServiceImpl.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/service/myPage/ResumeServiceImpl.java
@@ -1,0 +1,418 @@
+package org.zerock.ziczone.service.myPage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.zerock.ziczone.domain.application.*;
+import org.zerock.ziczone.domain.member.PersonalUser;
+import org.zerock.ziczone.domain.member.User;
+import org.zerock.ziczone.dto.mypage.*;
+import org.zerock.ziczone.exception.mypage.PersonalNotFoundException;
+import org.zerock.ziczone.exception.mypage.UserNotFoundException;
+import org.zerock.ziczone.repository.application.*;
+import org.zerock.ziczone.repository.member.PersonalUserRepository;
+import org.zerock.ziczone.repository.member.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeServiceImpl implements ResumeService {
+
+    private final ResumeRepository resumeRepository;
+    private final ArchiveRepository archiveRepository;
+    private final EtcRepository etcRepository;
+    private final CurriculumRepository curriculumRepository;
+    private final CareerRepository careerRepository;
+    private final EducationRepository educationRepository;
+    private final CertificateRepository certificateRepository;
+    private final UserRepository userRepository;
+    private final PersonalUserRepository personalUserRepository;
+
+
+    /**
+     * 지원서 생성
+     * 지원서와 관련된 자격증, 학력, 아카이브, 경력사항, 교육사항, 기타사항들을 같이 생성한다.
+     * 만약 테이블에 조회된 값이 없을 경우엔 새로 생성을 해준다.
+     * @param resumeDTO
+     * @param userId
+     * @return ResumeDTO
+     */
+    @Override
+    @Transactional
+    public ResumeDTO createResume(ResumeDTO resumeDTO, Long userId) {
+        User user = userRepository.findByUserId(userId);
+        if (user == null) {
+            throw new UserNotFoundException("User not found");
+        }
+        PersonalUser personalUser = personalUserRepository.findByUser_UserId(userId);
+        if (personalUser == null) {
+            throw new PersonalNotFoundException("Personal user not found");
+        }
+        Resume resume = resumeDTO.toEntity();
+        resume = resume.toBuilder().personalUser(personalUser).build();
+        Resume savedResume = resumeRepository.save(resume);
+
+        saveOrUpdateArchive(resumeDTO.getArchive(), savedResume);
+        saveOrUpdateEtcs(resumeDTO.getEtcs(), savedResume);
+        saveOrUpdateCurriculums(resumeDTO.getCurriculums(), savedResume);
+        saveOrUpdateCareers(resumeDTO.getCareers(), savedResume);
+        saveOrUpdateEducations(resumeDTO.getEducations(), savedResume);
+        saveOrUpdateCertificates(resumeDTO.getCertificates(), savedResume);
+
+        return ResumeDTO.fromEntity(savedResume);
+    }
+
+    /**
+     * 지원서 조회
+     * 지원서 조회시 없을 경우 지원서 생성 메서드를 가져와서 저장한다.그리고 조회해서 값을 불러온다.
+     * @param userId
+     * @return resumeDTO
+     */
+    @Override
+    @Transactional
+    public ResumeDTO getResume(Long userId) {
+        PersonalUser personalUser = personalUserRepository.findByUser_UserId(userId);
+        if (personalUser == null) {
+            throw new PersonalNotFoundException("Personal user not found");
+        }
+        Optional<List<Resume>> resumesOptional = resumeRepository.findByPersonalUser(personalUser);
+
+        Resume resume;
+        if (resumesOptional.isPresent() && !resumesOptional.get().isEmpty()) {
+            resume = resumesOptional.get().get(0);
+        } else {
+            resume = createEmptyResume(personalUser);
+            resume = resumeRepository.save(resume);
+        }
+
+        ResumeDTO resumeDTO = ResumeDTO.fromEntity(resume);
+        ArchiveDTO archiveDTO = getOrCreateArchive(resume);
+        List<EtcDTO> etcs = getOrCreateEtcs(resume);
+        List<CurriculumDTO> curriculums = getOrCreateCurriculums(resume);
+        List<CareerDTO> careers = getOrCreateCareers(resume);
+        List<EducationDTO> educations = getOrCreateEducations(resume);
+        List<CertificateDTO> certificates = getOrCreateCertificates(resume);
+
+        resumeDTO = resumeDTO.toBuilder()
+                .archive(archiveDTO)
+                .etcs(etcs)
+                .curriculums(curriculums)
+                .careers(careers)
+                .educations(educations)
+                .certificates(certificates)
+                .build();
+
+        return resumeDTO;
+    }
+
+    /**
+     *  지원서 수정
+     *  지원서 수정시 필요한 부분만 요청을 보내면 수정이 가능하다. 해당 테이블들의 id값은 필수로 필요하다. (조회시 값을 전달 함)
+     * @param userId
+     * @param resumeDTO
+     * @return
+     */
+    @Override
+    @Transactional
+    public ResumeDTO updateResume(Long userId, ResumeDTO resumeDTO) {
+        PersonalUser personalUser = personalUserRepository.findByUser_UserId(userId);
+        if (personalUser == null) {
+            throw new PersonalNotFoundException("Personal user not found");
+        }
+        Optional<List<Resume>> resumesOptional = resumeRepository.findByPersonalUser(personalUser);
+
+        if (resumesOptional.isPresent() && !resumesOptional.get().isEmpty()) {
+            Resume resume = resumesOptional.get().get(0);
+
+            Resume.ResumeBuilder resumeBuilder = resume.toBuilder();
+
+            resumeBuilder.resumeName(getValueOrEmpty(resumeDTO.getResumeName(), resume.getResumeName()));
+            resumeBuilder.resumeDate(getValueOrEmpty(resumeDTO.getResumeDate(), resume.getResumeDate()));
+            resumeBuilder.phoneNum(getValueOrEmpty(resumeDTO.getPhoneNum(), resume.getPhoneNum()));
+            resumeBuilder.resumePhoto(getValueOrEmpty(resumeDTO.getResumePhoto(), resume.getResumePhoto()));
+            resumeBuilder.resumeCreate(getValueOrEmpty(resumeDTO.getResumeCreate(), resume.getResumeCreate()));
+            resumeBuilder.resumeUpdate(getValueOrEmpty(resumeDTO.getResumeUpdate(), resume.getResumeUpdate()));
+            resumeBuilder.personalState(getValueOrEmpty(resumeDTO.getPersonalState(), resume.getPersonalState()));
+            resumeBuilder.resumeEmail(getValueOrEmpty(resumeDTO.getResumeEmail(), resume.getResumeEmail()));
+
+            Resume updatedResume = resumeRepository.save(resumeBuilder.personalUser(personalUser).build());
+
+            saveOrUpdateArchive(resumeDTO.getArchive(), updatedResume);
+            saveOrUpdateEtcs(resumeDTO.getEtcs(), updatedResume);
+            saveOrUpdateCurriculums(resumeDTO.getCurriculums(), updatedResume);
+            saveOrUpdateCareers(resumeDTO.getCareers(), updatedResume);
+            saveOrUpdateEducations(resumeDTO.getEducations(), updatedResume);
+            saveOrUpdateCertificates(resumeDTO.getCertificates(), updatedResume);
+
+            return getResumeDTOWithDefaults(updatedResume);
+        } else {
+            throw new IllegalArgumentException("Resume not found for the given user.");
+        }
+    }
+
+
+    /**
+     * 지원서 삭제
+     * 지원서 삭제시 관련된 테이블들의 모든 데이터를 전부 삭제한다.
+     * @param userId
+     */
+    @Transactional
+    @Override
+    public void deleteResume(Long userId) {
+        User user = userRepository.findByUserId(userId);
+        if (user == null) {
+            throw new UserNotFoundException("User not found");
+        }
+
+        PersonalUser personalUser = personalUserRepository.findByUser_UserId(userId);
+        if (personalUser == null) {
+            throw new PersonalNotFoundException("Personal user not found");
+        }
+
+        List<Resume> resumes = resumeRepository.findByPersonalUser(personalUser)
+                .orElseThrow(() -> new IllegalArgumentException("No Resume entity for the given user."));
+
+        Resume resume = resumes.get(0); // assuming we take the first resume if multiple exist
+
+        try {
+            archiveRepository.deleteByResume_ResumeId(resume.getResumeId());
+            etcRepository.deleteByResume_ResumeId(resume.getResumeId());
+            curriculumRepository.deleteByResume_ResumeId(resume.getResumeId());
+            careerRepository.deleteByResume_ResumeId(resume.getResumeId());
+            educationRepository.deleteByResume_ResumeId(resume.getResumeId());
+            certificateRepository.deleteByResume_ResumeId(resume.getResumeId());
+            resumeRepository.deleteById(resume.getResumeId());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete resume and related entities", e);
+        }
+    }
+
+
+    /**
+     *   아래부터는 Helper Method
+     *
+     */
+
+
+    private ResumeDTO getResumeDTOWithDefaults(Resume resume) {
+        ResumeDTO resumeDTO = ResumeDTO.fromEntity(resume);
+        resumeDTO = resumeDTO.toBuilder()
+                .archive(getOrCreateArchive(resume))
+                .etcs(getOrCreateEtcs(resume))
+                .curriculums(getOrCreateCurriculums(resume))
+                .careers(getOrCreateCareers(resume))
+                .educations(getOrCreateEducations(resume))
+                .certificates(getOrCreateCertificates(resume))
+                .build();
+        return resumeDTO;
+    }
+
+    private void saveOrUpdateArchive(ArchiveDTO archiveDTO, Resume resume) {
+        if (archiveDTO == null) {
+            archiveDTO = ArchiveDTO.builder().arch_git("").arch_notion("").arch_blog("").build();
+        }
+        Archive archive = archiveRepository.findByResume_ResumeId(resume.getResumeId())
+                .stream().findFirst().orElse(new Archive());
+        archiveRepository.save(archive.toBuilder()
+                .archGit(getValueOrEmpty(archiveDTO.getArch_git(), archive.getArchGit()))
+                .archNotion(getValueOrEmpty(archiveDTO.getArch_notion(), archive.getArchNotion()))
+                .archBlog(getValueOrEmpty(archiveDTO.getArch_blog(), archive.getArchBlog()))
+                .resume(resume)
+                .build());
+    }
+
+    private void saveOrUpdateEtcs(List<EtcDTO> etcs, Resume resume) {
+        etcRepository.deleteByResume_ResumeId(resume.getResumeId());
+        if (etcs == null) {
+            etcs = List.of(EtcDTO.builder().etc_content("").etc_date("").build());
+        }
+        for (EtcDTO etc : etcs) {
+            etcRepository.save(Etc.builder()
+                    .etcId(etc.getEtc_id())
+                    .etcContent(getValueOrEmpty(etc.getEtc_content(), ""))
+                    .etcDate(getValueOrEmpty(etc.getEtc_date(), ""))
+                    .resume(resume)
+                    .build());
+        }
+    }
+
+    private void saveOrUpdateCurriculums(List<CurriculumDTO> curriculums, Resume resume) {
+        curriculumRepository.deleteByResume_ResumeId(resume.getResumeId());
+        if (curriculums == null) {
+            curriculums = List.of(CurriculumDTO.builder().curri_content("").curri_company("").curri_date("").build());
+        }
+        for (CurriculumDTO curriculum : curriculums) {
+            curriculumRepository.save(Curriculum.builder()
+                    .curriId(curriculum.getCurri_id())
+                    .curriContent(getValueOrEmpty(curriculum.getCurri_content(), ""))
+                    .curriCompany(getValueOrEmpty(curriculum.getCurri_company(), ""))
+                    .curriDate(getValueOrEmpty(curriculum.getCurri_date(), ""))
+                    .resume(resume)
+                    .build());
+        }
+    }
+
+    private void saveOrUpdateCareers(List<CareerDTO> careers, Resume resume) {
+        careerRepository.deleteByResume_ResumeId(resume.getResumeId());
+        if (careers == null) {
+            careers = List.of(CareerDTO.builder().career_name("").career_job("").career_position("").career_date("").build());
+        }
+        for (CareerDTO career : careers) {
+            careerRepository.save(Career.builder()
+                    .careerId(career.getCareer_id())
+                    .careerName(getValueOrEmpty(career.getCareer_name(), ""))
+                    .careerJob(getValueOrEmpty(career.getCareer_job(), ""))
+                    .careerPosition(getValueOrEmpty(career.getCareer_position(), ""))
+                    .careerDate(getValueOrEmpty(career.getCareer_date(), ""))
+                    .resume(resume)
+                    .build());
+        }
+    }
+
+    private void saveOrUpdateEducations(List<EducationDTO> educations, Resume resume) {
+        educationRepository.deleteByResume_ResumeId(resume.getResumeId());
+        if (educations == null) {
+            educations = List.of(EducationDTO.builder().edu("").credit("").edu_date("").build());
+        }
+        for (EducationDTO education : educations) {
+            educationRepository.save(Education.builder()
+                    .eduId(education.getEdu_id())
+                    .edu(getValueOrEmpty(education.getEdu(), ""))
+                    .credit(getValueOrEmpty(education.getCredit(), ""))
+                    .eduDate(getValueOrEmpty(education.getEdu_date(), ""))
+                    .resume(resume)
+                    .build());
+        }
+    }
+
+    private void saveOrUpdateCertificates(List<CertificateDTO> certificates, Resume resume) {
+        certificateRepository.deleteByResume_ResumeId(resume.getResumeId());
+        if (certificates == null) {
+            certificates = List.of(CertificateDTO.builder().cert("").cert_date("").build());
+        }
+        for (CertificateDTO certificate : certificates) {
+            certificateRepository.save(Certificate.builder()
+                    .certId(certificate.getCert_id())
+                    .cert(getValueOrEmpty(certificate.getCert(), ""))
+                    .certDate(getValueOrEmpty(certificate.getCert_date(), ""))
+                    .resume(resume)
+                    .build());
+        }
+    }
+
+    private <T> T getValueOrEmpty(T value, T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+
+    private Resume createEmptyResume(PersonalUser personalUser) {
+        return Resume.builder()
+                .resumeName("")
+                .resumeDate("")
+                .phoneNum("")
+                .resumePhoto("")
+                .resumeCreate(LocalDateTime.now())
+                .resumeUpdate(LocalDateTime.now())
+                .resumeEmail("")
+                .personalState("")
+                .personalUser(personalUser)
+                .build();
+    }
+
+    private ArchiveDTO getOrCreateArchive(Resume resume) {
+        List<Archive> archives = archiveRepository.findByResume_ResumeId(resume.getResumeId());
+        if (!archives.isEmpty()) {
+            return ArchiveDTO.fromEntity(archives.get(0));
+        } else {
+            Archive archive = Archive.builder()
+                    .archGit("")
+                    .archNotion("")
+                    .archBlog("")
+                    .resume(resume)
+                    .build();
+            return ArchiveDTO.fromEntity(archiveRepository.save(archive));
+        }
+    }
+
+    private List<EtcDTO> getOrCreateEtcs(Resume resume) {
+        List<EtcDTO> etcs = etcRepository.findByResume_ResumeId(resume.getResumeId()).stream()
+                .map(EtcDTO::fromEntity)
+                .collect(Collectors.toList());
+        if (etcs.isEmpty()) {
+            Etc emptyEtc = Etc.builder()
+                    .etcContent("")
+                    .etcDate("")
+                    .resume(resume)
+                    .build();
+            etcs = List.of(EtcDTO.fromEntity(etcRepository.save(emptyEtc)));
+        }
+        return etcs;
+    }
+
+    private List<CurriculumDTO> getOrCreateCurriculums(Resume resume) {
+        List<CurriculumDTO> curriculums = curriculumRepository.findByResume_ResumeId(resume.getResumeId()).stream()
+                .map(CurriculumDTO::fromEntity)
+                .collect(Collectors.toList());
+        if (curriculums.isEmpty()) {
+            Curriculum emptyCurriculum = Curriculum.builder()
+                    .curriContent("")
+                    .curriCompany("")
+                    .curriDate("")
+                    .resume(resume)
+                    .build();
+            curriculums = List.of(CurriculumDTO.fromEntity(curriculumRepository.save(emptyCurriculum)));
+        }
+        return curriculums;
+    }
+
+    private List<CareerDTO> getOrCreateCareers(Resume resume) {
+        List<CareerDTO> careers = careerRepository.findByResume_ResumeId(resume.getResumeId()).stream()
+                .map(CareerDTO::fromEntity)
+                .collect(Collectors.toList());
+        if (careers.isEmpty()) {
+            Career emptyCareer = Career.builder()
+                    .careerName("")
+                    .careerJob("")
+                    .careerPosition("")
+                    .careerDate("")
+                    .resume(resume)
+                    .build();
+            careers = List.of(CareerDTO.fromEntity(careerRepository.save(emptyCareer)));
+        }
+        return careers;
+    }
+
+    private List<EducationDTO> getOrCreateEducations(Resume resume) {
+        List<EducationDTO> educations = educationRepository.findByResume_ResumeId(resume.getResumeId()).stream()
+                .map(EducationDTO::fromEntity)
+                .collect(Collectors.toList());
+        if (educations.isEmpty()) {
+            Education emptyEducation = Education.builder()
+                    .edu("")
+                    .credit("")
+                    .eduDate("")
+                    .resume(resume)
+                    .build();
+            educations = List.of(EducationDTO.fromEntity(educationRepository.save(emptyEducation)));
+        }
+        return educations;
+    }
+
+    private List<CertificateDTO> getOrCreateCertificates(Resume resume) {
+        List<CertificateDTO> certificates = certificateRepository.findByResume_ResumeId(resume.getResumeId()).stream()
+                .map(CertificateDTO::fromEntity)
+                .collect(Collectors.toList());
+        if (certificates.isEmpty()) {
+            Certificate emptyCertificate = Certificate.builder()
+                    .cert("")
+                    .certDate("")
+                    .resume(resume)
+                    .build();
+            certificates = List.of(CertificateDTO.fromEntity(certificateRepository.save(emptyCertificate)));
+        }
+        return certificates;
+    }
+}

--- a/ziczone/src/test/java/org/zerock/ziczone/repository/UserRepositoryTests.java
+++ b/ziczone/src/test/java/org/zerock/ziczone/repository/UserRepositoryTests.java
@@ -497,8 +497,8 @@ public class UserRepositoryTests {
 
         Payment payment = Payment.builder()
                 .payState(PayState.SUCCESS)
-                .payNum(1000L)
-                .berryPoint(100L)
+                .payNum(1000)
+                .berryPoint(100)
                 .personalUser(personalUser)
                 .build();
         paymentRepository.save(payment);

--- a/ziczone/src/test/java/org/zerock/ziczone/service/MyPageServiceTests.java
+++ b/ziczone/src/test/java/org/zerock/ziczone/service/MyPageServiceTests.java
@@ -1,18 +1,26 @@
 package org.zerock.ziczone.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-import org.zerock.ziczone.dto.mypage.CompanyUserDTO;
-import org.zerock.ziczone.dto.mypage.PersonalUserDTO;
+import org.zerock.ziczone.domain.member.*;
+import org.zerock.ziczone.dto.mypage.*;
 import org.zerock.ziczone.repository.PayHistoryRepository;
-import org.zerock.ziczone.repository.application.ResumeRepository;
+import org.zerock.ziczone.repository.application.*;
+import org.zerock.ziczone.repository.member.CompanyUserRepository;
 import org.zerock.ziczone.repository.member.PersonalUserRepository;
+import org.zerock.ziczone.repository.member.UserRepository;
 import org.zerock.ziczone.service.myPage.MyPageService;
+import org.zerock.ziczone.service.myPage.ResumeServiceImpl;
 
+import java.time.LocalDate;
 import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @Slf4j
 @SpringBootTest
@@ -24,36 +32,154 @@ public class MyPageServiceTests {
     @Autowired
     private PayHistoryRepository payHistoryRepository;
     @Autowired
-    private PersonalUserRepository personalUserRepository;
+    private ResumeServiceImpl resumeService;
 
-    // 테스트용 유저 User 테이블 PK
-    private final Long user_id = 1L;
     @Autowired
     private ResumeRepository resumeRepository;
 
-    /**
-     * @용도 : 기업회원 조회
-     * @request : Long user_id
-     * @response  : CompanyUserDTO
-     */
-    @Test
-    public void getCompanyUserDTO() {
-        CompanyUserDTO companyUserDTO = myPageService.getCompanyUserDTO(user_id);
+    @Autowired
+    private ArchiveRepository archiveRepository;
 
+    @Autowired
+    private EtcRepository etcRepository;
+
+    @Autowired
+    private CurriculumRepository curriculumRepository;
+
+    @Autowired
+    private CareerRepository careerRepository;
+
+    @Autowired
+    private EducationRepository educationRepository;
+
+    @Autowired
+    private CertificateRepository certificateRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CompanyUserRepository companyUserRepository;
+    @Autowired
+    private PersonalUserRepository personalUserRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+
+    private final Long user_id = 231212L;
+    private User testUser;
+    private PersonalUser testPersonalUser;
+    private CompanyUser testCompanyUser;
+
+    @BeforeEach
+    void setUp() {
+        String encryptedPassword = passwordEncoder.encode("password");
+        testUser = User.builder()
+                .email("testuser@example.com")
+                .password(passwordEncoder.encode("password"))
+                .userName("Test User")
+                .userIntro("Intro")
+                .userType(UserType.PERSONAL)
+                .build();
+
+        userRepository.save(testUser);
+
+        testPersonalUser = PersonalUser.builder()
+                .personalCareer("신입")
+                .isPersonalVisible(true)
+                .isCompanyVisible(false)
+                .gender(Gender.MALE)
+                .user(testUser)
+                .build();
+
+        personalUserRepository.save(testPersonalUser);
+        // User 엔티티와 PersonalUser 엔티티 간의 관계 설정
+        testUser.toBuilder().personalUser(testPersonalUser).build();
+        userRepository.save(testUser);
+        // 기본 Resume 생성
+        resumeService.getResume(testUser.getUserId());
+
+
+        testCompanyUser = CompanyUser.builder()
+                .user(testUser)
+                .companyAddr("Test Address")
+                .companyLogo("test_logo.png")
+                .companyCeo("Test CEO")
+                .companyNum("12345")
+                .companyYear(LocalDate.now())
+                .build();
+        companyUserRepository.saveAndFlush(testCompanyUser);
+    }
+
+    // 기업 회원 조회
+    @Test
+    void testGetCompanyUserDTO() {
+        CompanyUserDTO companyUserDTO = myPageService.getCompanyUserDTO(testUser.getUserId());
+        assertThat(companyUserDTO).isNotNull();
+        assertThat(companyUserDTO.getCompanyAddr()).isEqualTo(testCompanyUser.getCompanyAddr());
         log.info("CompanyUserDTO: " + companyUserDTO);
     }
-
-    /**
-     * @용도 : 개인회원 조회
-     * @request : Long user_id
-     * @response  : PersonalUserDTO
-     */
+    // 기업 회원 정보 수정
     @Test
-    public void getPersonalUserDTO() {
-        PersonalUserDTO personalUserDTO = myPageService.getPersonalUserDTO(user_id);
+    void testUpdateCompanyUser() {
+        CompanyUserUpdateDTO updateDTO = CompanyUserUpdateDTO.builder()
+                .currentPassword("password")
+                .changePassword("NewPassword123!")
+                .companyAddr("New Address")
+                .companyLogo("new_logo.png")
+                .userName("Updated User")
+                .userIntro("Updated Introduction")
+                .build();
+
+        String result = myPageService.updateCompanyUser(testUser.getUserId(), updateDTO);
+        assertThat(result).isEqualTo("User Information Updated Successfully");
+
+        CompanyUserDTO updatedCompanyUserDTO = myPageService.getCompanyUserDTO(testUser.getUserId());
+        assertThat(updatedCompanyUserDTO.getCompanyAddr()).isEqualTo("New Address");
+        assertThat(updatedCompanyUserDTO.getUser().getUserName()).isEqualTo("Updated User");
+        assertThat(updatedCompanyUserDTO.getUser().getUserIntro()).isEqualTo("Updated Introduction");
+    }
+    // 개인 회원 조회
+    @Test
+    void testGetPersonalUserDTO() {
+        PersonalUserDTO personalUserDTO = myPageService.getPersonalUserDTO(testUser.getUserId());
+        assertThat(personalUserDTO).isNotNull();
+        assertThat(personalUserDTO.getPersonalCareer()).isEqualTo(testPersonalUser.getPersonalCareer());
         log.info("PersonalUserDTO: " + personalUserDTO);
     }
-    
-    
+
+    // 테스트시 실제 저장된 유저데이터로 조회
+    @Test
+    void testGetAggregatedData() {
+        AggregatedDataDTO aggregatedDataDTO = myPageService.getAggregatedData(2L);
+        assertThat(aggregatedDataDTO).isNotNull();
+        assertThat(aggregatedDataDTO.getPersonalUsers()).isNotNull();
+        log.info("AggregatedDataDTO: " + aggregatedDataDTO);
+    }
+
+    // 테스트 시 실제 저장된 데이터로 조회 할 것
+    @Test
+    void testGetPicksByCompanyUsers() {
+        List<PersonalUserDTO> picks = myPageService.getPicksByCompanyUsers(1L);
+        assertThat(picks).isNotNull();
+        log.info("Picks by Company Users: " + picks);
+    }
+
+
+    @Test
+    void testGetPicksByPersonalUsers() {
+        List<CompanyUserDTO> picks = myPageService.getPicksByPersonalUsers(2L);
+        assertThat(picks).isNotNull();
+        log.info("Picks by Personal Users: " + picks);
+    }
+
+    @Test
+    void testMyCommList() {
+        List<MyCommentListDTO> commentList = myPageService.MyCommList(2L);
+        assertThat(commentList).isNotNull();
+        log.info("My Comment List: " + commentList);
+    }
+
+
+
 
 }


### PR DESCRIPTION
# 한 일
## 1. 지원서 생성

지원서와 관련된 자격증, 학력, 아카이브, 경력사항, 교육사항, 기타사항들을 같이 생성한다.
만약 테이블에 조회된 값이 없을 경우엔 새로 생성을 해준다.
## 2. 지원서 조회 시
GET : http://localhost:12000/api/resumes/{userId}
지원서 조회시 없을 경우 지원서 생성 메서드를 가져와서 저장한다.그리고 조회해서 값을 불러온다.
## 3. 지원서 수정
PUT : http://localhost:12000/api/resumes/{userId}
지원서 수정시 필요한 부분만 요청을 보내면 수정이 가능하다. 해당 테이블들의 id값은 필수로 필요하다. (조회시 값을 전달 함)

## 4. 지원서 삭제
지원서 삭제시 관련된 테이블들의 모든 데이터를 전부 삭제한다.
## 5. 테스트 코드 작성
오류 안나는 테스트 코드만 작성